### PR TITLE
Allow most recent slm version to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "slm": "^0.6.0",
+    "slm": ">=0.6.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
slm 1.0.0 is out.  This patch lets gulp-slm use it.

I opted to use `>=0.6.0` so that the package still works with the older version, in case someone out there doesn't want to update.  If you prefer though, I can change this to `^1.0.0` instead.